### PR TITLE
Set default for news_feed in news app in admin, not model. Resolves #29.

### DIFF
--- a/cms/apps/news/admin.py
+++ b/cms/apps/news/admin.py
@@ -5,7 +5,8 @@ from django.contrib import admin
 
 from cms import externals
 from cms.admin import PageBaseAdmin
-from cms.apps.news.models import Category, Article, STATUS_CHOICES
+from cms.apps.news.models import Category, Article, STATUS_CHOICES, \
+    get_default_news_feed
 
 
 class CategoryAdmin(PageBaseAdmin):
@@ -74,6 +75,11 @@ class ArticleAdminBase(PageBaseAdmin):
                 fieldset[1]['fields'] = tuple(x for x in fieldset[1]['fields'] if x != 'status')
 
         return fieldsets
+
+    def get_form(self, request, obj=None, **kwargs):
+        form = super(ArticleAdminBase, self).get_form(request, obj, **kwargs)
+        form.base_fields['news_feed'].initial = get_default_news_feed()
+        return form
 
     def formfield_for_choice_field(self, db_field, request, **kwargs):
         """

--- a/cms/apps/news/migrations/0005_auto_20151005_1441.py
+++ b/cms/apps/news/migrations/0005_auto_20151005_1441.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('news', '0004_auto_20151002_1655'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='article',
+            name='news_feed',
+            field=models.ForeignKey(to='news.NewsFeed', null=True),
+        ),
+    ]

--- a/cms/apps/news/models.py
+++ b/cms/apps/news/models.py
@@ -130,7 +130,8 @@ class Article(PageBase):
 
     news_feed = models.ForeignKey(
         NewsFeed,
-        default=get_default_news_feed,
+        null=True,
+        blank=False,
     )
 
     date = models.DateField(

--- a/cms/apps/news/tests/test_admin.py
+++ b/cms/apps/news/tests/test_admin.py
@@ -102,7 +102,7 @@ class TestArticleAdminBase(TestCase):
             ('submitted', 'Submitted for approval'),
         ])
 
-    def test_articleadminbase_save_related(self):
+    def test_articleadminbase_get_form(self):
         form = self.article_admin.get_form(self.request, obj=None)
         default_feed = get_default_news_feed()
         self.assertTrue("news_feed" in form.base_fields)

--- a/cms/apps/news/tests/test_admin.py
+++ b/cms/apps/news/tests/test_admin.py
@@ -5,7 +5,7 @@ from django.test import TestCase, RequestFactory
 from django.utils.timezone import now
 
 from ..admin import ArticleAdminBase
-from ..models import Article, Category, NewsFeed
+from ..models import Article, Category, NewsFeed, get_default_news_feed
 from ...pages.models import Page
 from .... import externals
 
@@ -101,3 +101,9 @@ class TestArticleAdminBase(TestCase):
             ('draft', 'Draft'),
             ('submitted', 'Submitted for approval'),
         ])
+
+    def test_articleadminbase_save_related(self):
+        form = self.article_admin.get_form(self.request, obj=None)
+        default_feed = get_default_news_feed()
+        self.assertTrue("news_feed" in form.base_fields)
+        self.assertEqual(default_feed, form.base_fields["news_feed"].initial)


### PR DESCRIPTION
Fixing my last PR, which unintentionally included a bunch of changes that had nothing to do with this.

Don't set a callable default in the Article model for news_feed. It is a recipe for migration tears.

Instead, make news_feed nullable, but not allowed to be blank. In the admin, set an initial default for news_feed, which will be the same as the previous get_default_news_feed default on the model's field. Same effect with less breakage.

The suggestion in bug #29 to see if "migrate" was in sys.argv did not strike me as a very durable way of fixing this.