### PR TITLE
Media: Fix UnicodeDecodeError for non-ASCII image titles

### DIFF
--- a/cms/apps/media/admin.py
+++ b/cms/apps/media/admin.py
@@ -1,4 +1,5 @@
 """Admin settings for the static media management application."""
+from __future__ import unicode_literals
 
 import os
 from functools import partial


### PR DESCRIPTION
Currently, if an image contains non-ASCII characters (ord > 127) characters, it will cause the get_preview function to fail which will give a 500 error on the image listing page. This fixes it by prefixing the returned string with `u`.