### PR TITLE
Fix unicode titles in get_context_data method of SearchMetaBase.

### DIFF
--- a/cms/models/base.py
+++ b/cms/models/base.py
@@ -1,6 +1,7 @@
 """Abstract base models used by the page management application."""
 from __future__ import unicode_literals
 
+import six
 from django.db import models
 from django.shortcuts import render
 from django.utils.encoding import python_2_unicode_compatible
@@ -215,7 +216,7 @@ class SearchMetaBase(OnlineBase):
 
     def get_context_data(self):
         """Returns the SEO context data for this page."""
-        title = str(self)
+        title = six.text_type(self)
         # Return the context.
         return {
             "meta_description": self.meta_description,


### PR DESCRIPTION
The `SearchMetaBase` class has the `get_context_data` method, so that views can update their context with the title, SEO title, OG stuff, etc from the model. 

If its derivatives have unicode characters in their title this causes an exception on Python 2 because the `title` key put into the context is created by `str(self)`.

This fixes it by using `six.text_type(self)`.