### PR TITLE
[Resolves #135] Restore CacheMixin and page-level caching

### DIFF
--- a/cms/apps/pages/views.py
+++ b/cms/apps/pages/views.py
@@ -1,10 +1,11 @@
 """Views used by the pages app."""
 
+from cms.views import CacheMixin
 from django.contrib.contenttypes.models import ContentType
 from django.views.generic import TemplateView
 
 
-class ContentIndexView(TemplateView):
+class ContentIndexView(CacheMixin, TemplateView):
 
     """Displays the index page for a page."""
 

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 from django.views import generic
-from six import text_type
+from six import binary_type
 
 from ..views import SearchMetaDetailMixin, TextTemplateView, CacheMixin
 
@@ -45,4 +45,4 @@ class TestViews(TestCase):
             with self.settings(CMS_CACHE_PAGES=do_caching):
                 request = self.factory.get('/')
                 response = test_view.dispatch(request)
-                self.assertEqual(response.content, text_type('foo'))
+                self.assertEqual(response.content, binary_type('foo'))

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 from django.views import generic
-from six import text_type
+from six import binary_type
 
 from ..views import SearchMetaDetailMixin, TextTemplateView, CacheMixin
 
@@ -45,4 +45,4 @@ class TestViews(TestCase):
             with self.settings(CMS_CACHE_PAGES=do_caching):
                 request = self.factory.get('/')
                 response = test_view.dispatch(request)
-                self.assertEqual(text_type(response.content), text_type('foo'))
+                self.assertEqual(binary_type(response.content), binary_type('foo'))

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 from django.views import generic
+from six import text_type
 
 from ..views import SearchMetaDetailMixin, TextTemplateView, CacheMixin
 
@@ -44,4 +45,4 @@ class TestViews(TestCase):
             with self.settings(CMS_CACHE_PAGES=do_caching):
                 request = self.factory.get('/')
                 response = test_view.dispatch(request)
-                self.assertEqual(response.content, 'foo')
+                self.assertEqual(response.content, text_type('foo'))

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -45,4 +45,4 @@ class TestViews(TestCase):
             with self.settings(CMS_CACHE_PAGES=do_caching):
                 request = self.factory.get('/')
                 response = test_view.dispatch(request)
-                self.assertEqual(response.content, binary_type('foo'))
+                self.assertEqual(text_type(response.content), text_type('foo'))

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 from django.views import generic
-from six import binary_type
+from six import text_type
 
 from ..views import SearchMetaDetailMixin, TextTemplateView, CacheMixin
 

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -1,6 +1,6 @@
-from django.test import TestCase
-from django.views import generic
 from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+from django.views import generic
 
 from ..views import SearchMetaDetailMixin, TextTemplateView, CacheMixin
 
@@ -11,6 +11,8 @@ class CacheTestView(CacheMixin, generic.View):
 
 
 class TestViews(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
 
     def test_texttemplateview_render_to_response(self):
         view = TextTemplateView()
@@ -36,9 +38,10 @@ class TestViews(TestCase):
     def test_cachemixin(self):
         test_view = CacheTestView()
 
-        self.assertEqual(test_view.get_cache_timeout(), view.cache_timeout)
+        self.assertEqual(test_view.get_cache_timeout(), test_view.cache_timeout)
 
         for do_caching in [True, False]:
             with self.settings(CMS_CACHE_PAGES=do_caching):
-                response = view.render_to_response()
+                request = self.factory.get('/')
+                response = test_view.dispatch(request)
                 self.assertEqual(response.content, 'foo')

--- a/cms/views.py
+++ b/cms/views.py
@@ -59,13 +59,13 @@ class CacheMixin(object):
         return self.cache_timeout
 
     def dispatch(self, *args, **kwargs):
-        response = super(CacheMixin, self).dispatch(*args, **kwargs)
+        dispatch = super(CacheMixin, self).dispatch
 
         if getattr(settings, 'CMS_CACHE_PAGES', False):
-            return response
+            return dispatch(*args, **kwargs)
 
         # Don't cache pages for logged-in users.
         if hasattr(self.request, 'user') and self.request.user.is_authenticated():
-            return response
+            return dispatch(*args, **kwargs)
 
-        return cache_page(self.get_cache_timeout())(response)
+        return cache_page(self.get_cache_timeout())(dispatch)(*args, **kwargs)


### PR DESCRIPTION
checks a setting to see whether or not this should be used - defaults to false