### PR TITLE
Remove WebM support from media app

### DIFF
--- a/cms/apps/media/admin.py
+++ b/cms/apps/media/admin.py
@@ -84,7 +84,6 @@ FILE_ICONS = {
     "mp4": MOVIE_FILE_ICON,
     "mov": MOVIE_FILE_ICON,
     "wmv": MOVIE_FILE_ICON,
-    'webm': MOVIE_FILE_ICON,
     'm4v': MOVIE_FILE_ICON,
 }
 

--- a/cms/apps/media/models.py
+++ b/cms/apps/media/models.py
@@ -175,7 +175,7 @@ class ImageRefField(FileRefField):
 
 
 VIDEO_FILTER = {
-    "file__iregex": r"\.(webm|mp4|m4v)$"
+    "file__iregex": r"\.(mp4|m4v)$"
 }
 
 
@@ -210,12 +210,6 @@ class Video(models.Model):
         verbose_name="low resolution MP4",
         blank=True,
         null=True
-    )
-
-    webm = VideoFileRefField(
-        verbose_name="WebM",
-        blank=True,
-        null=True,
     )
 
     def __str__(self):

--- a/cms/apps/media/tests/test_models.py
+++ b/cms/apps/media/tests/test_models.py
@@ -170,7 +170,7 @@ class TestVideo(TransactionTestCase):
 
         self.assertEqual(
             obj._meta.get_field('video_file').get_limit_choices_to(),
-            {'file__iregex': '\\.(webm|mp4|m4v)$'}
+            {'file__iregex': '\\.(mp4|m4v)$'}
         )
 
         obj.delete()


### PR DESCRIPTION
Remove all occurrences of WebM from the CMS as it is unnecessary now as all browsers support mp4.