### PR TITLE
Make is_online admin list editable.

### DIFF
--- a/cms/apps/pages/admin.py
+++ b/cms/apps/pages/admin.py
@@ -72,6 +72,8 @@ class PageAdmin(PageBaseAdmin):
 
     list_display = ("__str__", "is_online",)
 
+    list_editable = ("is_online",)
+
     list_filter = [PageContentTypeFilter]
 
     new_fieldsets = [


### PR DESCRIPTION
Fairly straightforward improvement to the main pages list to allow toggling of online status directly.