### PR TITLE
Fix issue with multilingual and offline pages

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.1 - 26/07/2019
+
+* Fix issue for multilingual site and offline pages [[See #176](https://github.com/onespacemedia/cms/pull/176/files)]
+
 ## 4.0.0 - 26/07/2019
 
 * Decouple from django-suit

--- a/cms/apps/pages/models.py
+++ b/cms/apps/pages/models.py
@@ -38,6 +38,9 @@ class PageManager(OnlineBaseManager):
                     WHERE
                         {ancestors}.{left} < {page_alias}.{left} AND
                         {ancestors}.{right} > {page_alias}.{right} AND (
+                            {ancestors}.{country_group_id} = {page_alias}.{country_group_id} OR
+                            {ancestors}.{country_group_id} IS NULL
+                        ) AND (
                             {ancestors}.{is_online} = FALSE OR
                             {ancestors}.{publication_date} > %s OR
                             {ancestors}.{expiry_date} <= %s
@@ -52,6 +55,7 @@ class PageManager(OnlineBaseManager):
                         'ancestors',
                         'left',
                         'right',
+                        'country_group_id',
                         'is_online',
                         'publication_date',
                         'expiry_date',


### PR DESCRIPTION
This fixes an issue with the PageManager that when a translation for a page if turned offline, all the child pages will be turned offline, even if they are for a different language