### PR TITLE
Allow ContentBase derivatives to control how their pages are indexed by Watson

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,7 +1,8 @@
 # Changelog
 
-## Next release
+## Next release (4.1.0?)
 * Remove `cached_url` from the Page model, because it is [unreliable](https://github.com/onespacemedia/cms/pull/181).
+* Make it possible for ContentBase derivatives to override how they are searched by Watson.
 
 ## 4.0.9 - 11/10/2019
 

--- a/cms/apps/pages/models.py
+++ b/cms/apps/pages/models.py
@@ -460,7 +460,7 @@ class ContentBase(models.Model):
         given lower priority than the title of the page it is attached to.
 
         By default this will return every text field on the ContentBase,
-        joined by spaces. A common case for overriding this is when your
+        separated by a space. A common case for overriding this is when your
         page's content is built out of other models.
         '''
         return ' '.join([
@@ -470,6 +470,7 @@ class ContentBase(models.Model):
                 in self._meta.fields
                 if isinstance(field, (models.CharField, models.TextField))
             ]
+            # Because we don't want to index "None" :)
             if getattr(self, field_name)
         ])
 

--- a/cms/apps/pages/models.py
+++ b/cms/apps/pages/models.py
@@ -71,7 +71,6 @@ class PageManager(OnlineBaseManager):
         return self.prefetch_related('child_set__child_set').get(parent=None,
                                                                  is_content_object=False)
 
-
 class Page(PageBase):
 
     '''A page within the site.'''
@@ -461,6 +460,24 @@ class ContentBase(models.Model):
 
     class Meta:
         abstract = True
+
+    def get_searchable_text(self):
+        '''
+        Returns a blob of text that will be indexed by Watson. This will be
+        given lower priority than the title of the page it is attached to.
+
+        By default this will return every text field on the ContentBase,
+        joined by spaces. A common case for overriding this is when your
+        page's content is built out of other models.
+        '''
+        return ' '.join(
+            force_text(self._resolve_field(self, field_name))
+            for field_name in (
+                field.name for field
+                in self._meta.fields
+                if isinstance(field, (models.CharField, models.TextField))
+            )
+        )
 
 
 class Country(models.Model):

--- a/cms/apps/pages/models.py
+++ b/cms/apps/pages/models.py
@@ -376,17 +376,10 @@ class PageSearchAdapter(PageBaseSearchAdapter):
         '''Returns the search text for the page.'''
         content_obj = obj.content
 
-        return ' '.join((
+        return ' '.join([
             super().get_content(obj),
-            self.prepare_content(' '.join(
-                force_text(self._resolve_field(content_obj, field_name))
-                for field_name in (
-                    field.name for field
-                    in content_obj._meta.fields
-                    if isinstance(field, (models.CharField, models.TextField))
-                )
-            ))
-        ))
+            self.prepare_content(content_obj.get_searchable_text())
+        ])
 
     def get_live_queryset(self):
         '''Selects the live page queryset.'''
@@ -470,14 +463,15 @@ class ContentBase(models.Model):
         joined by spaces. A common case for overriding this is when your
         page's content is built out of other models.
         '''
-        return ' '.join(
-            force_text(self._resolve_field(self, field_name))
-            for field_name in (
+        return ' '.join([
+            force_text(getattr(self, field_name))
+            for field_name in [
                 field.name for field
                 in self._meta.fields
                 if isinstance(field, (models.CharField, models.TextField))
-            )
-        )
+            ]
+            if getattr(self, field_name)
+        ])
 
 
 class Country(models.Model):

--- a/cms/apps/pages/tests/test_models.py
+++ b/cms/apps/pages/tests/test_models.py
@@ -20,7 +20,10 @@ class TestPageContent(ContentBase):
 
 
 class TestPageContentWithSections(ContentBase):
-    pass
+    testing = models.CharField(
+        max_length=20,
+        default='testing',
+    )
 
 
 class Section(models.Model):
@@ -235,7 +238,7 @@ class TestSectionPage(TestCase):
         search_adapter = PageSearchAdapter(Page)
 
         content = search_adapter.get_content(self.homepage)
-        self.assertEqual(content, '      homepage Homepage  ')
+        self.assertEqual(content, '      homepage Homepage  testing')
 
 
 class TestPageComplex(TestCase):


### PR DESCRIPTION
Currently, `PageSearchAdapter` will examine all `CharField` and `TextField` derivatives on the page's content model to work out what should be indexed by the internal search engine. This works well, when pages are largely built out of those field types.

However, it doesn't allow searching deeper into other types of field, such as `ForeignKey`s. The obvious use case is our standard [sections app](https://github.com/onespacemedia/project-template/blob/develop/%7B%7Bcookiecutter.repo_name%7D%7D/%7B%7Bcookiecutter.package_name%7D%7D/apps/sections/models.py), where all or nearly all of the page's content is built out of other models.

This changes the behaviour to add `get_searchable_text` to `ContentBase`, which is called by `get_content` on `PageSearchAdapter`. This will allow derivatives to override what text is seen by `get_content`.

As a bonus, this also improves the tests - it does not appear to have been testing the text field search indexing at all, because the test model had no text fields on it.