### PR TITLE
Make all ForeignKey/OneToOneField fields specify on_delete behaviour.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next release
+* Ensure all `ForeignKey`s have an `on_delete` explicitly specified for Django 2.2 compatibility.
+
 ## 4.0.10 - 18/10/2019
 * Fix `Video.embed_html()` function using the wrong renderer for local mp4 files.
 * Remove `cached_url` from the Page model, because it is [unreliable](https://github.com/onespacemedia/cms/pull/181).

--- a/cms/apps/links/migrations/0001_initial.py
+++ b/cms/apps/links/migrations/0001_initial.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Link',
             fields=[
-                ('page', models.OneToOneField(related_name='+', primary_key=True, serialize=False, editable=False, to='pages.Page')),
+                ('page', models.OneToOneField(related_name='+', primary_key=True, serialize=False, editable=False, to='pages.Page', on_delete=models.CASCADE)),
                 ('link_url', cms.models.fields.LinkField(help_text=b'The URL where the user will be redirected.', max_length=1000, verbose_name=b'link URL')),
                 ('new_window', models.BooleanField(default=False, help_text=b'Open the page in a new window.')),
             ],

--- a/cms/apps/pages/migrations/0001_initial.py
+++ b/cms/apps/pages/migrations/0001_initial.py
@@ -55,10 +55,10 @@ class Migration(migrations.Migration):
                 ('expiry_date', models.DateTimeField(help_text='The date that this page will be removed from the website.  Leave this blank to never expire this page.', null=True, db_index=True, blank=True)),
                 ('in_navigation', models.BooleanField(default=True, help_text='Uncheck this box to remove this content from the site navigation.', verbose_name='add to navigation')),
                 ('cached_url', models.CharField(max_length=1000, null=True, blank=True)),
-                ('content_type', models.ForeignKey(editable=False, to='contenttypes.ContentType', help_text='The type of page content.')),
-                ('country_group', models.ForeignKey(blank=True, to='pages.CountryGroup', null=True)),
-                ('owner', models.ForeignKey(related_name='owner_set', blank=True, to='pages.Page', null=True)),
-                ('parent', models.ForeignKey(related_name='child_set', blank=True, to='pages.Page', null=True)),
+                ('content_type', models.ForeignKey(editable=False, to='contenttypes.ContentType', help_text='The type of page content.', on_delete=models.CASCADE)),
+                ('country_group', models.ForeignKey(blank=True, to='pages.CountryGroup', null=True, on_delete=models.CASCADE)),
+                ('owner', models.ForeignKey(related_name='owner_set', blank=True, to='pages.Page', null=True, on_delete=models.CASCADE)),
+                ('parent', models.ForeignKey(related_name='child_set', blank=True, to='pages.Page', null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('left',),
@@ -67,7 +67,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='country',
             name='group',
-            field=models.ForeignKey(blank=True, to='pages.CountryGroup', null=True),
+            field=models.ForeignKey(blank=True, to='pages.CountryGroup', null=True, on_delete=models.CASCADE),
         ),
         migrations.AlterUniqueTogether(
             name='page',

--- a/cms/apps/pages/models.py
+++ b/cms/apps/pages/models.py
@@ -85,6 +85,7 @@ class Page(PageBase):
         blank=True,
         null=True,
         related_name='child_set',
+        on_delete=models.CASCADE,
     )
 
     left = models.IntegerField(
@@ -104,7 +105,8 @@ class Page(PageBase):
     country_group = models.ForeignKey(
         'pages.CountryGroup',
         blank=True,
-        null=True
+        null=True,
+        on_delete=models.CASCADE,
     )
 
     owner = models.ForeignKey(
@@ -163,6 +165,7 @@ class Page(PageBase):
         ContentType,
         editable=False,
         help_text='The type of page content.',
+        on_delete=models.CASCADE,
     )
 
     requires_authentication = models.BooleanField(
@@ -453,6 +456,7 @@ class ContentBase(models.Model):
         primary_key=True,
         editable=False,
         related_name='+',
+        on_delete=models.CASCADE,
     )
 
     def __str__(self):
@@ -475,7 +479,8 @@ class Country(models.Model):
     group = models.ForeignKey(
         'pages.CountryGroup',
         blank=True,
-        null=True
+        null=True,
+        on_delete=models.CASCADE,
     )
 
     default = models.NullBooleanField(


### PR DESCRIPTION
In Django 2.2, `on_delete` is a required argument.

This PR does not change any behaviour; `models.CASCADE` used to be the default behaviour, and this preserves that. Arguably that is the *wrong* behaviour in some cases (like deleting a `CountryGroup` nuking your entire page hierarchy), but that can be discussed separately.

This edits a couple of migrations. I would normally discourage doing this, but this is necessary to avoid `RemovedInDjango20Warning` (with `python -Wd`), and it does not actually change the migration state since `CASCADE` is what it was doing before.