### PR TITLE
[Fix #140] Make middleware compatible with MIDDLEWARE setting.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next release
+* Make middleware compatible with both `MIDDLEWARE` and `MIDDLEWARE_CLASSES`.
+
 ## 4.0.10 - 18/10/2019
 * Fix `Video.embed_html()` function using the wrong renderer for local mp4 files.
 * Remove `cached_url` from the Page model, because it is [unreliable](https://github.com/onespacemedia/cms/pull/181).

--- a/cms/apps/pages/admin.py
+++ b/cms/apps/pages/admin.py
@@ -42,6 +42,10 @@ PAGE_FROM_SITEMAP_VALUE = 'sitemap'
 # The GET parameter used to indicate content type on page creation.
 PAGE_TYPE_PARAMETER = 'type'
 
+# We check this a couple of times to see if we are localised. We prefer
+# MIDDLEWARE, but support MIDDLEWARE_CLASSES for compatibility with older
+# projects and older Djangos.
+SETTINGS_MIDDLEWARE = getattr(settings, 'MIDDLEWARE_CLASSES', settings.MIDDLEWARE)
 
 class PageContentTypeFilter(admin.SimpleListFilter):
     '''Enables filtering of pages by their content type.'''
@@ -425,7 +429,7 @@ class PageAdmin(PageBaseAdmin):
             ).order_by('-country_group')
 
         extra_context['display_language_options'] = False
-        if 'cms.middleware.LocalisationMiddleware' in settings.MIDDLEWARE_CLASSES:
+        if 'cms.middleware.LocalisationMiddleware' in SETTINGS_MIDDLEWARE:
             extra_context['display_language_options'] = True
 
         # Call the change view.
@@ -705,7 +709,7 @@ class CountryAdmin(admin.ModelAdmin):
 
 admin.site.register(Page, PageAdmin)
 
-if 'cms.middleware.LocalisationMiddleware' in settings.MIDDLEWARE_CLASSES:
+if 'cms.middleware.LocalisationMiddleware' in SETTINGS_MIDDLEWARE:
     admin.site.register(Country, CountryAdmin)
     admin.site.register(CountryGroup, CountryGroupAdmin)
 

--- a/cms/apps/pages/admin.py
+++ b/cms/apps/pages/admin.py
@@ -42,11 +42,6 @@ PAGE_FROM_SITEMAP_VALUE = 'sitemap'
 # The GET parameter used to indicate content type on page creation.
 PAGE_TYPE_PARAMETER = 'type'
 
-# We check this a couple of times to see if we are using the localisation
-# middleware. We support MIDDLEWARE_CLASSES for compatibility with older
-# projects and older Djangos.
-SETTINGS_MIDDLEWARE = getattr(settings, 'MIDDLEWARE', None) or settings.MIDDLEWARE_CLASSES
-
 
 class PageContentTypeFilter(admin.SimpleListFilter):
     '''Enables filtering of pages by their content type.'''
@@ -430,7 +425,8 @@ class PageAdmin(PageBaseAdmin):
             ).order_by('-country_group')
 
         extra_context['display_language_options'] = False
-        if 'cms.middleware.LocalisationMiddleware' in SETTINGS_MIDDLEWARE:
+        middleware = getattr(settings, 'MIDDLEWARE', None) or settings.MIDDLEWARE_CLASSES
+        if 'cms.middleware.LocalisationMiddleware' in middleware:
             extra_context['display_language_options'] = True
 
         # Call the change view.
@@ -710,7 +706,9 @@ class CountryAdmin(admin.ModelAdmin):
 
 admin.site.register(Page, PageAdmin)
 
-if 'cms.middleware.LocalisationMiddleware' in SETTINGS_MIDDLEWARE:
+middleware = getattr(settings, 'MIDDLEWARE', None) or settings.MIDDLEWARE_CLASSES
+
+if 'cms.middleware.LocalisationMiddleware' in middleware:
     admin.site.register(Country, CountryAdmin)
     admin.site.register(CountryGroup, CountryGroupAdmin)
 

--- a/cms/apps/pages/admin.py
+++ b/cms/apps/pages/admin.py
@@ -42,8 +42,8 @@ PAGE_FROM_SITEMAP_VALUE = 'sitemap'
 # The GET parameter used to indicate content type on page creation.
 PAGE_TYPE_PARAMETER = 'type'
 
-# We check this a couple of times to see if we are localised. We prefer
-# MIDDLEWARE, but support MIDDLEWARE_CLASSES for compatibility with older
+# We check this a couple of times to see if we are using the localisation
+# middleware. We support MIDDLEWARE_CLASSES for compatibility with older
 # projects and older Djangos.
 SETTINGS_MIDDLEWARE = getattr(settings, 'MIDDLEWARE_CLASSES', settings.MIDDLEWARE)
 

--- a/cms/apps/pages/admin.py
+++ b/cms/apps/pages/admin.py
@@ -45,7 +45,8 @@ PAGE_TYPE_PARAMETER = 'type'
 # We check this a couple of times to see if we are using the localisation
 # middleware. We support MIDDLEWARE_CLASSES for compatibility with older
 # projects and older Djangos.
-SETTINGS_MIDDLEWARE = getattr(settings, 'MIDDLEWARE_CLASSES', settings.MIDDLEWARE)
+SETTINGS_MIDDLEWARE = getattr(settings, 'MIDDLEWARE', None) or settings.MIDDLEWARE_CLASSES
+
 
 class PageContentTypeFilter(admin.SimpleListFilter):
     '''Enables filtering of pages by their content type.'''
@@ -709,6 +710,7 @@ class CountryAdmin(admin.ModelAdmin):
 
 admin.site.register(Page, PageAdmin)
 
+print(SETTINGS_MIDDLEWARE)
 if 'cms.middleware.LocalisationMiddleware' in SETTINGS_MIDDLEWARE:
     admin.site.register(Country, CountryAdmin)
     admin.site.register(CountryGroup, CountryGroupAdmin)

--- a/cms/apps/pages/admin.py
+++ b/cms/apps/pages/admin.py
@@ -710,7 +710,6 @@ class CountryAdmin(admin.ModelAdmin):
 
 admin.site.register(Page, PageAdmin)
 
-print(SETTINGS_MIDDLEWARE)
 if 'cms.middleware.LocalisationMiddleware' in SETTINGS_MIDDLEWARE:
     admin.site.register(Country, CountryAdmin)
     admin.site.register(CountryGroup, CountryGroupAdmin)

--- a/cms/apps/pages/middleware.py
+++ b/cms/apps/pages/middleware.py
@@ -8,6 +8,7 @@ from django.core.handlers.base import BaseHandler
 from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import SimpleTemplateResponse
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import cached_property
 from django.views.debug import technical_404_response
 
@@ -120,7 +121,7 @@ class RequestPageManager:
         return self.current.get_absolute_url() == self._path
 
 
-class PageMiddleware:
+class PageMiddleware(MiddlewareMixin):
 
     '''Serves up pages when no other view is matched.'''
 

--- a/cms/apps/pages/tests/test_admin.py
+++ b/cms/apps/pages/tests/test_admin.py
@@ -554,11 +554,11 @@ class TestPageAdmin(TestCase):
 
         response = self.page_admin.change_view(request, str(self.homepage.pk))
 
-        NEW_MIDDLEWARE_CLASSES = [
+        NEW_MIDDLEWARE = [
             'cms.middleware.LocalisationMiddleware',
-        ] + list(settings.MIDDLEWARE_CLASSES)
+        ] + list(settings.MIDDLEWARE)
 
-        with self.settings(MIDDLEWARE_CLASSES=NEW_MIDDLEWARE_CLASSES):
+        with self.settings(MIDDLEWARE=NEW_MIDDLEWARE):
             request = self._build_request()
             response = self.page_admin.change_view(request, str(self.homepage.pk))
             self.assertEqual(response.status_code, 200)

--- a/cms/apps/pages/tests/test_admin.py
+++ b/cms/apps/pages/tests/test_admin.py
@@ -554,11 +554,7 @@ class TestPageAdmin(TestCase):
 
         response = self.page_admin.change_view(request, str(self.homepage.pk))
 
-        NEW_MIDDLEWARE = [
-            'cms.middleware.LocalisationMiddleware',
-        ] + list(settings.MIDDLEWARE)
-
-        with self.settings(MIDDLEWARE=NEW_MIDDLEWARE):
+        with self.settings(MIDDLEWARE=['cms.middleware.LocalisationMiddleware']):
             request = self._build_request()
             response = self.page_admin.change_view(request, str(self.homepage.pk))
             self.assertEqual(response.status_code, 200)

--- a/cms/apps/pages/tests/test_admin_destructive.py
+++ b/cms/apps/pages/tests/test_admin_destructive.py
@@ -10,14 +10,10 @@ from ..models import Country, CountryGroup, Page
 class TestArticleAdminBase(TestCase):
 
     def test_article_admin(self):
-        NEW_MIDDLEWARE = (
-            'cms.middleware.LocalisationMiddleware',
-        ) + tuple(settings.MIDDLEWARE)
-
         self.assertNotIn(Country, admin.site._registry)
         self.assertNotIn(CountryGroup, admin.site._registry)
 
-        with self.settings(MIDDLEWARE=NEW_MIDDLEWARE):
+        with self.settings(MIDDLEWARE=['cms.middleware.LocalisationMiddleware']):
             module = sys.modules['cms.apps.pages.admin']
             del sys.modules['cms.apps.pages.admin']
 

--- a/cms/apps/pages/tests/test_admin_destructive.py
+++ b/cms/apps/pages/tests/test_admin_destructive.py
@@ -10,14 +10,14 @@ from ..models import Country, CountryGroup, Page
 class TestArticleAdminBase(TestCase):
 
     def test_article_admin(self):
-        NEW_MIDDLEWARE_CLASSES = (
+        NEW_MIDDLEWARE = (
             'cms.middleware.LocalisationMiddleware',
-        ) + tuple(settings.MIDDLEWARE_CLASSES)
+        ) + tuple(settings.MIDDLEWARE)
 
         self.assertNotIn(Country, admin.site._registry)
         self.assertNotIn(CountryGroup, admin.site._registry)
 
-        with self.settings(MIDDLEWARE_CLASSES=NEW_MIDDLEWARE_CLASSES):
+        with self.settings(MIDDLEWARE=NEW_MIDDLEWARE):
             module = sys.modules['cms.apps.pages.admin']
             del sys.modules['cms.apps.pages.admin']
 


### PR DESCRIPTION
Somewhat overdue, as this was deprecated in 1.11 and is entirely removed in 2.2 LTS.

So that older projects and older Djangos don't break when updating, it supports both `MIDDLEWARE` and `MIDDLEWARE_CLASSES`.