### PR TITLE
Fix ObjectDoesNotExist exception recovering pages with Reversion: reloaded

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next release
+* Fix recovering Page objects with reversion.
+
 ## 4.3.0 - 2019-11-12
 * Importing `cms.sitemaps` at the top level of a module containing an app's AppConfig no longer raises `AppRegistryNotReady`.
 * `PageBase`'s help text for the `slug` field now makes sense.

--- a/cms/apps/pages/admin.py
+++ b/cms/apps/pages/admin.py
@@ -28,7 +28,7 @@ from django.template.defaultfilters import capfirst
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import six
-from watson.search import update_index
+from watson.search import search_context_manager, update_index
 
 from cms.admin import PageBaseAdmin
 from cms.apps.pages.models import (Country, CountryGroup, Page,
@@ -431,6 +431,14 @@ class PageAdmin(PageBaseAdmin):
 
         # Call the change view.
         return super().change_view(request, object_id, form_url=form_url, extra_context=extra_context)
+
+    def recover_view(self, request, version_id, extra_context=None):
+        '''
+        Stop Watson from trying to index the page during recovery (a situation
+        where PageInstance.content does not exist).
+        '''
+        search_context_manager.invalidate()
+        return super().recover_view(request, version_id, extra_context=extra_context)
 
     def revision_view(self, request, object_id, version_id, extra_context=None):
         '''Load up the correct content inlines.'''


### PR DESCRIPTION
This was previously done in #175. I prefer this implementation because:

1. It fixes it in one place, not two
2. It's addressing the problem, which is Watson throwing an exception on `.content`, in a narrower scope
3. It doesn't quietly swallow `ObjectDoesNotExist`, which is something that we absolutely *do* want to be thrown if it happens.